### PR TITLE
Docing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+## Contributing
+
+Naturally, you'll need Composer installed and running.
+
+1. Fork the repo
+2. Clone your fork locally
+3. Install the dependencies
+4. Run the tests
+5. Browse tests for more usage.
+
+```sh
+git clone https://github.com/mateu-aguilo-bosch/mpx-php
+composer install
+composer test
+```
+
+When you've got a patch ready, make sure the tests still pass, and try to write a new test that covers your change.

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,9 @@
       "email": "mateu.aguilo.bosch@gmail.com"
     }
   ],
+  "scripts": {
+    "test": "phpunit"
+  },
   "require": {
     "guzzlehttp/guzzle": "5.*",
     "pimple/pimple": "3.*"


### PR DESCRIPTION
We should also throw a `license` in… I know the `npm` community has really been pushing for package authors.  Some enterprises require license validation on all packages.
